### PR TITLE
Feature/antimeridian

### DIFF
--- a/GeoJSON.xcodeproj/project.pbxproj
+++ b/GeoJSON.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		B1D85EA91DA126F700469588 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D85EA81DA126F700469588 /* Feature.swift */; };
 		B1D85EAA1DA126FA00469588 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D85EA81DA126F700469588 /* Feature.swift */; };
 		B8534E6B24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8534E6A24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift */; };
+		B8534E6C24CF06BC00258A00 /* CLLocationCoordinate2D+Antimeridian.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8534E6A24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift */; };
+		B8534E6D24CF06C000258A00 /* CLLocationCoordinate2D+Antimeridian.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8534E6A24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -410,6 +412,7 @@
 			files = (
 				B120EE71207B899B00A4A7CA /* Feature.swift in Sources */,
 				B120EE6F207B899B00A4A7CA /* Geometry.swift in Sources */,
+				B8534E6D24CF06C000258A00 /* CLLocationCoordinate2D+Antimeridian.swift in Sources */,
 				B120EE70207B899B00A4A7CA /* Shapes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -441,6 +444,7 @@
 			files = (
 				B1D85EAA1DA126FA00469588 /* Feature.swift in Sources */,
 				B16B17FB1D9FCAB100B2EB68 /* Geometry.swift in Sources */,
+				B8534E6C24CF06BC00258A00 /* CLLocationCoordinate2D+Antimeridian.swift in Sources */,
 				B16B17FC1D9FCAB100B2EB68 /* Shapes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GeoJSON.xcodeproj/project.pbxproj
+++ b/GeoJSON.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B1A5CC611CD9039F004A22C7 /* TestCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A5CC601CD9039F004A22C7 /* TestCore.swift */; };
 		B1D85EA91DA126F700469588 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D85EA81DA126F700469588 /* Feature.swift */; };
 		B1D85EAA1DA126FA00469588 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D85EA81DA126F700469588 /* Feature.swift */; };
+		B8534E6B24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8534E6A24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,7 @@
 		B16B17F31D9FCAAA00B2EB68 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B1A5CC601CD9039F004A22C7 /* TestCore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCore.swift; sourceTree = "<group>"; };
 		B1D85EA81DA126F700469588 /* Feature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
+		B8534E6A24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+Antimeridian.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +153,7 @@
 				B159331D1CD8A13B00A5D192 /* GeoJSON.h */,
 				B159331F1CD8A13B00A5D192 /* Info.plist */,
 				B1D85EA81DA126F700469588 /* Feature.swift */,
+				B8534E6A24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift */,
 			);
 			path = GeoJSON;
 			sourceTree = "<group>";
@@ -417,6 +420,7 @@
 			files = (
 				B1D85EA91DA126F700469588 /* Feature.swift in Sources */,
 				B14D86431CD8BACE0000C7E6 /* Shapes.swift in Sources */,
+				B8534E6B24CF026000258A00 /* CLLocationCoordinate2D+Antimeridian.swift in Sources */,
 				B15933431CD8A46600A5D192 /* Geometry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GeoJSON/CLLocationCoordinate2D+Antimeridian.swift
+++ b/GeoJSON/CLLocationCoordinate2D+Antimeridian.swift
@@ -1,0 +1,39 @@
+//
+//  CLLocationCoordinate2D+Antimeridian.swift
+//  GeoJSON
+//
+//  Created by Ben Shutt on 27/07/2020.
+//  Copyright © 2020 threesidedcube. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+extension CLLocationCoordinate2D {
+    
+    var mappingLongitude: CLLocationCoordinate2D {
+        return CLLocationCoordinate2D(
+            latitude: latitude,
+            longitude: longitude.mappedLongitude
+        )
+    }
+}
+
+// MARK: - FloatingPoint + Antimeridian
+
+extension FloatingPoint {
+    
+    var mappedLongitude: Self {
+        return mappedLongitude(self)
+    }
+    
+    func mappedLongitude(_ longitude: Self) -> Self {
+        if longitude > 180 {
+            return mappedLongitude(longitude - 360)
+        } else if longitude <= -180 {
+            return mappedLongitude(longitude + 360)
+        }
+        
+        return longitude
+    }
+}

--- a/GeoJSON/Geometry.swift
+++ b/GeoJSON/Geometry.swift
@@ -129,6 +129,8 @@ open class Position: NSObject {
         
         latitude = coordinates.count > 1 ? coordinates[1] : 0.0
         longitude = coordinates.count > 0 ? coordinates[0] : 0.0
+        
+        longitude = longitude.mappedLongitude
     }
     
     /**


### PR DESCRIPTION
# Summary
Handle invalid longitude values mapping them to their equivalent in `(-180, 180]`.

# Warning
I see in the code when printed `.latLng` it returns `return CLLocationCoordinate2D(latitude: longitude, longitude: latitude)` which is worrying. Because I don't want to apply this function to a `latitude`!!