### PR TITLE
Fix incorrect parsed results for Antarctica coordinates.

### DIFF
--- a/GeoJSON/CLLocationCoordinate2D+Antimeridian.swift
+++ b/GeoJSON/CLLocationCoordinate2D+Antimeridian.swift
@@ -30,7 +30,7 @@ extension FloatingPoint {
     func mappedLongitude(_ longitude: Self) -> Self {
         if longitude > 180 {
             return mappedLongitude(longitude - 360)
-        } else if longitude <= -180 {
+        } else if longitude < -180 {
             return mappedLongitude(longitude + 360)
         }
         

--- a/GeoJSONTests/positionTests.swift
+++ b/GeoJSONTests/positionTests.swift
@@ -45,7 +45,16 @@ class positionTests: XCTestCase {
         XCTAssertEqual(coordinate2D.latitude, 20, "Coordinate has incorrect latitude")
         XCTAssertEqual(coordinate2D.longitude, 10, "Coordinate has incorrect longitude")
     }
-    
+
+    func testAntarcticaCoordinate() {
+
+        let position = Position(coordinates: [-180,-60])
+        let coordinate2D = position.coordinate
+
+        XCTAssertEqual(coordinate2D.latitude, -60, "Coordinate has incorrect latitude")
+        XCTAssertEqual(coordinate2D.longitude, -180, "Coordinate has incorrect longitude")
+    }
+
     func testLongLat() {
         
         let position = Position(coordinates: [10,20])


### PR DESCRIPTION
## What?

Fix the issue where the longitude changes from `-180` to `180` after parsing.

## Why?

The alert for Antarctica doesn’t appear in the app.

